### PR TITLE
[PHP] Allow “chapo” to contain formated text.

### DIFF
--- a/inc/conf.php
+++ b/inc/conf.php
@@ -133,11 +133,11 @@ function init_list_comments($comment) {
  */
 
 function init_post_article() { //no $mode : it's always admin.
-	$formated = formatage_wiki(protect_markup(clean_txt($_POST['contenu'])));
+	$formated_contenu = formatage_wiki(protect_markup(clean_txt($_POST['contenu'])));
 	if ($GLOBALS['automatic_keywords'] == '0') {
 		$keywords = htmlspecialchars(stripslashes(protect_markup(clean_txt($_POST['mots_cles']))));
 	} else {
-		$keywords = extraire_mots($_POST['titre'].' '.$formated);
+		$keywords = extraire_mots($_POST['titre'].' '.$formated_contenu);
 	}
 
 	$date = str4($_POST['annee']).str2($_POST['mois']).str2($_POST['jour']).str2($_POST['heure']).str2($_POST['minutes']).str2($_POST['secondes']);
@@ -147,9 +147,9 @@ function init_post_article() { //no $mode : it's always admin.
 		'bt_id'				=> $id,
 		'bt_date'			=> $date,
 		'bt_title'			=> htmlspecialchars(stripslashes(protect_markup(clean_txt($_POST['titre'])))),
-		'bt_abstract'		=> htmlspecialchars(stripslashes(protect_markup(clean_txt($_POST['chapo'])))),
+		'bt_abstract'		=> (empty($_POST['chapo']) ? '' : formatage_wiki(protect_markup(clean_txt($_POST['chapo'])))),
 		'bt_notes'			=> htmlspecialchars(stripslashes(protect_markup(clean_txt($_POST['notes'])))),
-		'bt_content'		=> $formated,
+		'bt_content'		=> $formated_contenu,
 		'bt_wiki_content'	=> stripslashes(protect_markup(clean_txt($_POST['contenu']))),
 		'bt_link'			=> '', // this one is not needed yet. Maybe in the futur. I dunno why it is still in the DB…
 		'bt_keywords'		=> $keywords,

--- a/inc/form.php
+++ b/inc/form.php
@@ -580,9 +580,11 @@ function afficher_form_billet($article, $erreurs) {
 
 	echo '<textarea id="contenu" name="contenu" rows="20" cols="60" required="" placeholder="'.ucfirst($GLOBALS['lang']['placeholder_contenu']).'" tabindex="55" class="text">'.$contenudefaut.'</textarea>'."\n" ;
 
-	echo form_categories_links('articles', $categoriesdefaut);
-	echo "\t".'<input list="htmlListTags" type="text" class="text" id="type_tags" name="tags" onkeydown="chkHit(event);" placeholder="'.ucfirst($GLOBALS['lang']['placeholder_tags']).'" tabindex="65"/>'."\n";
-	echo "\t".'<input type="hidden" id="categories" name="categories" value="" />'."\n";
+	if ($GLOBALS['activer_categories'] == '1') {
+		echo form_categories_links('articles', $categoriesdefaut);
+		echo "\t".'<input list="htmlListTags" type="text" class="text" id="type_tags" name="tags" onkeydown="chkHit(event);" placeholder="'.ucfirst($GLOBALS['lang']['placeholder_tags']).'" tabindex="65"/>'."\n";
+		echo "\t".'<input type="hidden" id="categories" name="categories" value="" />'."\n";
+	}
 
 	if ($GLOBALS['automatic_keywords'] == '0') {
 		echo '<div><input id="mots_cles" name="mots_cles" type="text" size="50" value="'.$motsclesdefaut.'" placeholder="'.ucfirst($GLOBALS['lang']['placeholder_motscle']).'" tabindex="67" class="text" /></div>'."\n";

--- a/inc/html.php
+++ b/inc/html.php
@@ -397,14 +397,18 @@ function liste_tags($billet, $html_link) {
 // AFFICHE LA LISTE DES ARTICLES, DANS LA PAGE ADMIN
 function afficher_liste_articles($tableau) {
 	if (!empty($tableau)) {
+		mb_internal_encoding('UTF-8');
 		$i = 0;
 		$out = '<ul id="billets">'."\n";
 		foreach ($tableau as $article) {
 			// ICONE SELON STATUT
 			$out .= "\t".'<li>'."\n";
 			// TITRE
-			$out .= "\t\t".'<span><span class="'.( ($article['bt_statut'] == '1') ? 'on' : 'off').'"></span>'.'<a href="ecrire.php?post_id='.$article['bt_id'].'" title="'.trim($article['bt_abstract']).'">'.$article['bt_title'].'</a>'.'</span>'."\n";
+			$out .= "\t\t".'<span><span class="'.( ($article['bt_statut'] == '1') ? 'on' : 'off').'"></span>'.'<a href="ecrire.php?post_id='.$article['bt_id'].'" title="'.trim(mb_substr(strip_tags($article['bt_abstract']), 0, 249)).'">'.$article['bt_title'].'</a>'.'</span>'."\n";
 			// DATE
+
+
+
 			$out .= "\t\t".'<span><a href="'.basename($_SERVER['PHP_SELF']).'?filtre='.substr($article['bt_date'],0,8).'">'.date_formate($article['bt_date']).'</a> @ '.heure_formate($article['bt_date']).'</span>'."\n";
 			// NOMBRE COMMENTS
 			$texte = $article['bt_nb_comments'];

--- a/themes/default/list.html
+++ b/themes/default/list.html
@@ -42,24 +42,24 @@
 		<nav id="liens">
 			<h3>Autres</h3>
 			<ul>
-				<li><a href="index.php" title="">Blog</a></li>
-				<li><a href="index.php?mode=links" title="">Liens</a></li>
-				<li><a href="index.php?mode=comments" title="">Derniers commentaires</a></li>
+				<li><a href="index.php">Blog</a></li>
+				<li><a href="index.php?mode=links">Liens</a></li>
+				<li><a href="index.php?mode=comments">Derniers commentaires</a></li>
 			</ul>
 			<hr/>
 		</nav>
 		<nav id="random">
 			<h3>Un article au hasard</h3>
 				<ul>
-					<li><a href="?random" title="">Un article au hasard ?</a></li>
+					<li><a href="?random">Un article au hasard ?</a></li>
 				</ul>
 			<hr/>
 		</nav>
 		<nav id="rss">
 			<h4>Fils RSS</h4>
 			<ul>
-				<li><a href="rss.php" title=""><img src="{style}/feed.png" alt="icon" /> RSS</a> : Blog</li>
-				<li><a href="rss.php?mode=links" title=""><img src="{style}/feed.png" alt="icon" /> RSS</a> : Liens</li>
+				<li><a href="rss.php"><img src="{style}/feed.png" alt="icon" /> RSS</a> : Blog</li>
+				<li><a href="rss.php?mode=links"><img src="{style}/feed.png" alt="icon" /> RSS</a> : Liens</li>
 			</ul>
 			<hr/>
 		</nav>

--- a/themes/default/template/article.html
+++ b/themes/default/template/article.html
@@ -1,7 +1,7 @@
 <article class="news">
 	<header class="titre">
-		<h2><a href="{article_lien}" title="{article_chapo}">{article_titre}</a></h2>
-		<h3 class="date"><img src="{style}/icon_date.png" alt="icon" /> {article_date} - <a href="{article_lien}#commentaires" title="">{nombre_commentaires}</a></h3>
+		<h2><a href="{article_lien}">{article_titre}</a></h2>
+		<h3 class="date"><img src="{style}/icon_date.png" alt="icon" /> {article_date} - <a href="{article_lien}#commentaires">{nombre_commentaires}</a></h3>
 	</header>
 	<!--<p class="chapo">{article_chapo}</p>-->
 	{article_contenu}

--- a/themes/default/template/commentaire.html
+++ b/themes/default/template/commentaire.html
@@ -1,8 +1,8 @@
 <article class="comment" id="{commentaire_ancre}">
 	<header>
 		<h3>
-			<a href="{commentaire_lien}" title="">#</a> - 
-			<a href="#form-commentaire" onclick="reply('[b]@[{commentaire_auteur}|#{commentaire_ancre}] :[/b] ');" title="">@</a> - 
+			<a href="{commentaire_lien}">#</a> - 
+			<a href="#form-commentaire" onclick="reply('[b]@[{commentaire_auteur}|#{commentaire_ancre}] :[/b] ');">@</a> - 
 			{commentaire_auteur_lien} - {commentaire_date} à {commentaire_heure}
 		</h3>
 	</header>

--- a/themes/default/template/link.html
+++ b/themes/default/template/link.html
@@ -1,6 +1,6 @@
 <article class="lien" id="{lien_permalink}">
 	<header class="titre">
-		<h2><a href="index.php?mode=links&amp;id={lien_permalink}" title="">#{lien_id}</a> - <a href="{lien_url}" rel="nofollow" title="">{lien_titre}</a></h2>
+		<h2><a href="index.php?mode=links&amp;id={lien_permalink}">#{lien_id}</a> - <a href="{lien_url}" rel="nofollow">{lien_titre}</a></h2>
 		<h3 class="date">{lien_date} à {lien_heure} par {lien_auteur}</h3>
 	</header>
 	<p>{lien_description}</p>

--- a/themes/default/template/post.html
+++ b/themes/default/template/post.html
@@ -1,6 +1,6 @@
 <article class="news news-alone">
 	<header class="titre">
-		<h2><a href="{article_lien}" title="{article_chapo}">{article_titre}</a></h2>
+		<h2><a href="{article_lien}">{article_titre}</a></h2>
 		<h3 class="date"><img src="{style}/icon_date.png" alt="icon" /> {article_date}</h3>
 	</header>
 	<!--<p class="chapo">{article_chapo}</p>-->
@@ -15,11 +15,11 @@
 	<article class="comment" id="{commentaire_ancre}">
 	<h3>{commentaire_auteur_lien} - {commentaire_date} à {commentaire_heure}  </h3>
 		{commentaire_contenu}
-		<p class="com-reply"><a href="#form-commentaire" onclick="reply('[b]@[{commentaire_auteur}|#{commentaire_ancre}] :[/b] ');" title="">@répondre</a> <a href="#{commentaire_ancre}" title="">#lien</a></p>
+		<p class="com-reply"><a href="#form-commentaire" onclick="reply('[b]@[{commentaire_auteur}|#{commentaire_ancre}] :[/b] ');" title="">@répondre</a> <a href="#{commentaire_ancre}">#lien</a></p>
 	</article>
 	{/BOUCLE_commentaires}
 
-	<p><a href="{rss_comments}" title=""><img src="{style}/feed.png" alt="icon" /> Flux RSS des commentaires de cet article</a></p>
+	<p><a href="{rss_comments}"><img src="{style}/feed.png" alt="icon" /> Flux RSS des commentaires de cet article</a></p>
 	<div id="postcom">
 		{formulaire_commentaire}
 	</div>


### PR DESCRIPTION
HTML/BBcode formated text in the chapo is not really recommended.

Also: bugfix for tags form that was displayed even when tags was set to off.